### PR TITLE
refactor: 리뷰 작성 요청/응답 DTO 클래스 이름 세분화

### DIFF
--- a/src/main/java/com/example/sodamsodam/apps/review/controller/ReviewController.java
+++ b/src/main/java/com/example/sodamsodam/apps/review/controller/ReviewController.java
@@ -1,7 +1,7 @@
 package com.example.sodamsodam.apps.review.controller;
 
-import com.example.sodamsodam.apps.review.dto.ReviewRequest;
-import com.example.sodamsodam.apps.review.dto.ReviewResponse;
+import com.example.sodamsodam.apps.review.dto.ReviewCreateRequest;
+import com.example.sodamsodam.apps.review.dto.ReviewCreateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -28,9 +28,9 @@ public class ReviewController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/{place_id}/reviews")
-    public ResponseEntity<ReviewResponse> createReview(@PathVariable Long place_id, @RequestBody @Valid ReviewRequest request) {
+    public ResponseEntity<ReviewCreateResponse> createReview(@PathVariable Long place_id, @RequestBody @Valid ReviewCreateRequest request) {
         // 리뷰 ID 값은 나중에 기능 구현후 생성된 리뷰 ID 값으로 대체 예정
-        ReviewResponse response = new ReviewResponse(1L,"리뷰가 성공적으로 등록되었습니다");
+        ReviewCreateResponse response = new ReviewCreateResponse(1L,"리뷰가 성공적으로 등록되었습니다");
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/example/sodamsodam/apps/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/example/sodamsodam/apps/review/dto/ReviewCreateRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @Schema(description = "리뷰 작성 요청 DTO")
-public class ReviewRequest {
+public class ReviewCreateRequest {
 
     @Schema(description = "리뷰 내용", example = "좋아요")
     @NotBlank(message = "내용은 필수입니다.")

--- a/src/main/java/com/example/sodamsodam/apps/review/dto/ReviewCreateResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/review/dto/ReviewCreateResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Schema(description = "리뷰 작성 응답 DTO")
-public class ReviewResponse {
+public class ReviewCreateResponse {
 
     @Schema(description = "생성된 리뷰의 ID", example = "1")
     private Long reviewId;


### PR DESCRIPTION
### 작업 내용
- 리뷰 작성에 대한 DTO를 너무 추상적으로 클래스 이름을 지정한거 같아서 변경했습니다 
- 추후 다른 API 추가 할때 겹치는 문제가 있기도 하고 일관성 있도록 유지하기 위해서 입니다
- ReviewRequest → ReviewCreateRequest로 변경
- ReviewResponse → ReviewCreateResponse로 변경
- 작성(Create) 기능 전용 DTO임을 명확히 표현

Close #27
