### PR TITLE
feat: 예약 목록 조회 API 기본 구현 (status 필터링만 적용)

### DIFF
--- a/src/main/java/com/example/sodamsodam/apps/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/controller/ReservationController.java
@@ -1,0 +1,43 @@
+package com.example.sodamsodam.apps.reservation.controller;
+
+import com.example.sodamsodam.apps.reservation.dto.ReservationListRequest;
+import com.example.sodamsodam.apps.reservation.dto.ReservationListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/reservations")
+@Tag(name = "Reservation", description = "예약 관련 API")
+public class ReservationController {
+
+    @Operation(summary = "예약 목록 조회", description = "로그인한 사용자의 예약 목록 조회 API입니다")
+    @GetMapping
+    public ResponseEntity<List<ReservationListResponse>> getReservations(
+            @ModelAttribute ReservationListRequest request
+    ){
+        // 실제 서비스 구현 전, 더미 데이터로 응답
+        log.info("예약 목록 조회 요청 - status: {}, page: {}, size: {}",
+                request.getStatus(), request.getPage(), request.getSize());
+
+        List<ReservationListResponse> dummyList = List.of(
+                ReservationListResponse.builder()
+                        .reservationId(1L)
+                        .placeName("카페 온더문")
+                        .reservedAt(LocalDateTime.of(2025, 6, 1, 14, 0))
+                        .status("UPCOMING")
+                        .build()
+        );
+
+        return ResponseEntity.ok(dummyList);
+    }
+}

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationCancelResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationCancelResponse.java
@@ -1,0 +1,22 @@
+package com.example.sodamsodam.apps.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "예약 취소 응답 DTO")
+public class ReservationCancelResponse {
+
+    @Schema(description = "예약 ID", example = "1")
+    private Long reservationId;
+
+    @Schema(description = "응답 메시지", example = "예약이 취소 완료")
+    private String message;
+
+    @Schema(description = "예약 상태", example = "canceled")
+    private String status;
+
+}

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationDetailResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationDetailResponse.java
@@ -5,25 +5,29 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
-@Schema(description = "예약 목록 응답 DTO")
-public class ReservationListResponse {
-
-    @Schema(description =  "예약 ID", example = "1")
+@Schema(description = "예약 상세 정보 응답 DTO")
+public class ReservationDetailResponse {
+    @Schema(description = "예약 ID", example = "1")
     private Long reservationId;
 
     @Schema(description = "장소 이름", example = "카페 온더문")
     private String placeName;
 
+    @Schema(description = "장소 주소", example = "서울특별시 강남구 테헤란로 123")
+    private String address;
+
+    @Schema(description = "예약 상태", example = "completed")
+    private String status;
+
     @Schema(description = "예약 일시", example = "2025-06-01T14:00:00")
     private LocalDateTime reservedAt;
 
-    @Schema(description = "예약 상태", example = "upcoming")
-    private String status;
+
+
 
 }

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationListRequest.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationListRequest.java
@@ -22,4 +22,6 @@ public class ReservationListRequest {
     @Schema(description = "페이지 당 항목 수", example = "10")
     private int size = 10;
 
+
+
 }

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReviewableReservationResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReviewableReservationResponse.java
@@ -1,0 +1,27 @@
+package com.example.sodamsodam.apps.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "리뷰 작성 가능한 예약 응답 DTO")
+public class ReviewableReservationResponse {
+    @Schema(description = "예약ID", example = "2")
+    private Long reservationId;
+
+    @Schema(description = "장소 이름", example = "루프탑 바")
+    private String placeName;
+
+    @Schema(description = "방문 일시", example = "2025-05-10T19:00:00")
+    private LocalDateTime visitedAt;
+
+    @Schema(description = "리뷰 작성 여부", example = "false")
+    private boolean reviewed;
+
+}

--- a/src/main/java/com/example/sodamsodam/apps/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/entity/Reservation.java
@@ -1,0 +1,55 @@
+package com.example.sodamsodam.apps.reservation.entity;
+
+import com.example.sodamsodam.apps.user.entity.UserPersonalInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reservation {
+    @JsonProperty("reservation_id")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserPersonalInfo user;
+
+    private LocalDateTime reservedAt;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+
+    public enum ReservationStatus {
+        UPCOMING, COMPLETED, CANCELLED
+    }
+
+
+    // 리뷰 작성 여부(리뷰 작성 가능한 예약 조건에 필요함)
+    private boolean reviewed;
+    public void markReviewed() {
+        this.reviewed = true;
+    }
+
+    public void cancel() {
+        this.status = ReservationStatus.CANCELLED;
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/sodamsodam/apps/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/service/ReservationService.java
@@ -1,0 +1,4 @@
+package com.example.sodamsodam.apps.reservation.service;
+
+public class ReservationService {
+}


### PR DESCRIPTION
구현내용
- 예약 목록 조회 API 작성
- status 파라미터에 따라 필터링 가능
- 각 기능 DTO 및  entity 작성

빠진내용
처음에 예약 일자정렬 기능이 필요할거 같았는데 현재 불필요하다고 느껴 기능구현에서 제외했습니다(심지어 명세서에도 안적혀있었음..)

확인사항
- Swagger UI에서 정상 출력 확인
- 로그인 유저 정보 연동은 추후 구현 예정

추후 할 일 
- 예약 상세 조회 / 예약 취소 API 추가 예정
- ReservationService 연결
- 로그인 유저 기반 예약 조회로 확장 