### PR TITLE
feat: 예약 상태 필터 및 리뷰 작성 가능 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/sodamsodam/apps/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/controller/ReservationController.java
@@ -1,67 +1,106 @@
 package com.example.sodamsodam.apps.reservation.controller;
 
 import com.example.sodamsodam.apps.reservation.dto.*;
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
+//import com.example.sodamsodam.apps.reservation.repository.ReservationRepository;
+import com.example.sodamsodam.apps.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/reservations")
 @Tag(name = "Reservation", description = "예약 관련 API")
 public class ReservationController {
 
-    @Operation(summary = "예약 목록 조회", description = "로그인한 사용자의 예약 목록 조회 API입니다")
-    @GetMapping
-    public ResponseEntity<List<ReservationListResponse>> getReservations(
-            @ModelAttribute ReservationListRequest request
-    ){
-        // 실제 서비스 구현 전, 더미 데이터로 응답
-        log.info("예약 목록 조회 요청 - status: {}, page: {}, size: {}",
-                request.getStatus(), request.getPage(), request.getSize());
+    private final ReservationService reservationService;
 
-        List<ReservationListResponse> dummyList = List.of(
-                ReservationListResponse.builder()
-                        .reservationId(1L)
-                        .placeName("카페 온더문")
-                        .reservedAt(LocalDateTime.of(2025, 6, 1, 14, 0))
-                        .status("UPCOMING")
-                        .build()
-        );
 
-        return ResponseEntity.ok(dummyList);
+    @Operation(summary = "예약 등록", description = "사용자가 새로운 예약을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예약 등록 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Map.class),
+                            examples = @ExampleObject(value = "{\"message\": \"예약 완료\", \"reservationId\": 42}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"error\": \"Invalid data\", \"code\": 400}")))
+    })
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> createReservation(@RequestBody ReservationCreateRequest request) {
+        Long reservationId = reservationService.createReservation(request);
+        return ResponseEntity.ok(Map.of(
+                    "message", "예약 완료",
+                "reservationId", reservationId));
     }
 
-    @Operation(summary = "예약 목록 상세 조회", description = "로그인한 사용자의 예약 상세 정보 조회 API 입니다")
-    @GetMapping("/{reservation_id}")
+
+
+    @Operation(summary = "유저 ID 기반 예약 목록 조회 (상태 필터링 가능)", description = "특정 유저의 예약 목록을 상태에 따라 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예약 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReservationListResponse.class))),
+            @ApiResponse(responseCode = "404", description = "유저 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"error\": \"User not found\", \"code\": 404}")))
+    })
+    @GetMapping("/user/{userId}/filter")
+    public ResponseEntity<List<ReservationListResponse>> getUserReservationsWithStatus(
+            @PathVariable Long userId,
+            @RequestParam(required = false) Reservation.ReservationStatus status
+    ) {
+        List<Reservation> reservations = (status == null)
+                ? reservationService.getReservations(userId)
+                : reservationService.getReservationsByStatus(userId, status);
+
+        List<ReservationListResponse> result = reservations.stream()
+                .map(ReservationListResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(result);
+    }
+
+
+
+
+
+    @Operation(summary = "예약 목록 상세 조회", description = "로그인한 사용자의 예약 상세 정보 조회 API입니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예약 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReservationDetailResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"error\": \"Unauthorized\", \"code\": 401}"))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 예약",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"error\": \"Reservation not found\", \"code\": 404}")))
+    })
+    @GetMapping("/{reservationId}")
     public ResponseEntity<ReservationDetailResponse> getReservationDetail(
-            //@PathVariable Long reservationId
-
-    ){
-        Long reservationId = 1L;//나중에 예약API만들고 추가할 예정
+            @PathVariable Long reservationId
+    ) {
         log.info("예약 상세 조회 요청 - reservationId: {}", reservationId);
-        ReservationDetailResponse dummy = ReservationDetailResponse.builder()
-                .reservationId(reservationId)
-                .placeName("카페 온더문")
-                .address("서울시 성동구...")
-                .reservedAt(LocalDateTime.of(2025, 6, 1, 14, 0))
-                .status("UPCOMING")
-                .build();
 
-        return ResponseEntity.ok(dummy);
+        Reservation reservation = reservationService.getReservationDetail(reservationId);
+        ReservationDetailResponse response = ReservationDetailResponse.from(reservation);
 
+        return ResponseEntity.ok(response);
     }
+
 
     @Operation(summary = "예약 취소", description = "사용자가 선택한 예약을 취소합니다.")
     @ApiResponses({
@@ -80,43 +119,42 @@ public class ReservationController {
     ) {
         log.info("예약 취소 요청 - reservationId: {}", reservationId);
 
+        Reservation cancelled = reservationService.cancelReservation(reservationId);
         ReservationCancelResponse response = new ReservationCancelResponse(
                 reservationId,
                 "예약 취소 완료",
-                "canceled"
+                cancelled.getStatus().name().toLowerCase()
         );
 
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "리뷰 작성 가능 예약 목록 조회", description = "리뷰를 작성할 수 있는 예약 목록을 조회합니다.")
-    @GetMapping("/reviewable")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 작성 가능 예약 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewableReservationResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"error\": \"Unauthorized\", \"code\": 401}"))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"error\": \"Internal Server Error\", \"code\": 500}")))
+    })
+    @GetMapping("/writeable")
     public ResponseEntity<List<ReviewableReservationResponse>> getReviewableReservations(
-            //@AuthenticationPrincipal UserPersonalInfo user 유저
-
+            @Parameter(description = "유저 ID", example = "7", required = true)
+            @RequestParam Long userId  // 추후 인증 붙이면 @AuthenticationPrincipal로 교체
     ) {
-        Long dummyUserId = 1L;//나중에 인증 붙이면 바꿀 예정
-        log.info("리뷰 가능 예약 목록 조회 - userId: {}", dummyUserId);
+        log.info("리뷰작성 가능 예약 목록 조회 - userId: {}", userId);
 
-        // 더미 응답 리스트
-        List<ReviewableReservationResponse> dummyList = List.of(
-                ReviewableReservationResponse.builder()
-                        .reservationId(2L)
-                        .placeName("루프탑 바")
-                        .reservedAt(LocalDateTime.of(2025, 5, 10, 19, 0))
-                        .reviewed(false)
-                        .build(),
-                ReviewableReservationResponse.builder()
-                        .reservationId(3L)
-                        .placeName("카페 몽블랑")
-                        .reservedAt(LocalDateTime.of(2025, 5, 12, 15, 0))
-                        .reviewed(true)// 서비스 구현할때 reviewed == false로 할 예정
-                        .build()
-        );
+        List<Reservation> reservations = reservationService.getNotReviewedReservations(userId);
 
-        return ResponseEntity.ok(dummyList);
+        List<ReviewableReservationResponse> result = reservations.stream()
+                .map(ReviewableReservationResponse::from)// 만약 리뷰 작성 가능한 예약이 없다면 빈배열로 뜹니다.
+                .toList();
+
+        return ResponseEntity.ok(result);
     }
-
 
 
 

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationCreateRequest.java
@@ -1,0 +1,32 @@
+package com.example.sodamsodam.apps.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "예약 생성 요청 DTO")
+public class ReservationCreateRequest {
+    @Schema(description = "유저 ID", required = true)
+    private Long userId;
+
+    @Schema(description = "카카오 장소 ID", required = true)
+    private String kakaoPlaceId;
+
+    @Schema(description = "장소 이름",required = true)
+    private String placeName;
+
+    @Schema(description = "장소 주소", required = true)
+    private String address;
+
+    @Schema(description = "예약 일시", example = "2025-06-01T14:00:00",required = true)
+    private LocalDateTime reservedAt;
+
+}

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationDetailResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationDetailResponse.java
@@ -1,5 +1,6 @@
 package com.example.sodamsodam.apps.reservation.dto;
 
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,16 @@ public class ReservationDetailResponse {
 
     @Schema(description = "예약 일시", example = "2025-06-01T14:00:00")
     private LocalDateTime reservedAt;
+
+    public static ReservationDetailResponse from(Reservation reservation) {
+        return ReservationDetailResponse.builder()
+                .reservationId(reservation.getReservationId())
+                .placeName(reservation.getPlaceName())
+                .address(reservation.getAddress())
+                .reservedAt(reservation.getReservedAt())
+                .status(reservation.getStatus().name().toLowerCase())
+                .build();
+    }
 
 
 

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationListRequest.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationListRequest.java
@@ -1,26 +1,32 @@
 package com.example.sodamsodam.apps.reservation.dto;
 
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @Schema(description = "예약 목록 조회 요청 DTO")
 public class ReservationListRequest {
 
-    public enum ReservationStatusType{
-        UPCOMING, COMPLETED, CANCELLED
+    //public enum ReservationStatusType{
+     //   UPCOMING, COMPLETED, CANCELLED
 
-    }
-    @Schema(description = "예약 상태 (upcoming, completed, canceled 중 하나)", example = "upcoming")
-    private ReservationStatusType status;
+    //}
+    @Schema(description = "예약 상태 (UPCOMING, COMPLETED, CANCELLED 중 하나)", example = "UPCOMING")
+    private Reservation.ReservationStatus status;
 
     @Schema(description = "페이지 번호 (1부터 시작)", example = "1")
     private int page = 1;
 
     @Schema(description = "페이지 당 항목 수", example = "10")
     private int size = 10;
+
+    @Schema(description = "유저 ID", example = "1")
+    private Long userId;
 
 
 

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationListResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReservationListResponse.java
@@ -1,5 +1,6 @@
 package com.example.sodamsodam.apps.reservation.dto;
 
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,10 +21,21 @@ public class ReservationListResponse {
     @Schema(description = "장소 이름", example = "카페 온더문")
     private String placeName;
 
+    @Schema(description = "장소 주소", example = "주소 정보")
+    private String address;
+
     @Schema(description = "예약 일시", example = "2025-06-01T14:00:00")
     private LocalDateTime reservedAt;
 
     @Schema(description = "예약 상태", example = "upcoming")
     private String status;
 
+    public static ReservationListResponse from(Reservation reservation) {
+        return ReservationListResponse.builder()
+                .reservationId(reservation.getReservationId())
+                .placeName(reservation.getPlaceName())
+                .reservedAt(reservation.getReservedAt())
+                .status(reservation.getStatus().name().toLowerCase())
+                .build();
+    }
 }

--- a/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReviewableReservationResponse.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/dto/ReviewableReservationResponse.java
@@ -1,5 +1,6 @@
 package com.example.sodamsodam.apps.reservation.dto;
 
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,4 +25,12 @@ public class ReviewableReservationResponse {
     @Schema(description = "리뷰 작성 여부", example = "false")
     private boolean reviewed;
 
+    public static ReviewableReservationResponse from(Reservation reservation) {
+        return ReviewableReservationResponse.builder()
+                .reservationId(reservation.getReservationId())
+                .placeName(reservation.getPlaceName())
+                .reservedAt(reservation.getReservedAt())
+                .reviewed(reservation.isReviewed())
+                .build();
+    }
 }

--- a/src/main/java/com/example/sodamsodam/apps/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/entity/Reservation.java
@@ -15,15 +15,26 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "reservation")
 public class Reservation {
     @JsonProperty("reservation_id")
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "id")
+    private Long reservationId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserPersonalInfo user;
+
+    @Column(name = "kakao_place_id")
+    private String kakaoPlaceId;
+
+    @Column(name = "place_name")
+    private String placeName;
+
+    @Column(name = "address")
+    private String address;
 
     private LocalDateTime reservedAt;
 
@@ -37,6 +48,7 @@ public class Reservation {
 
 
     // 리뷰 작성 여부(리뷰 작성 가능한 예약 조건에 필요함)
+    //리뷰작성 완료시 해당 예약의 reviewed필드를 true로 저장해줘야됨
     private boolean reviewed;
     public void markReviewed() {
         this.reviewed = true;

--- a/src/main/java/com/example/sodamsodam/apps/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/entity/Reservation.java
@@ -48,11 +48,9 @@ public class Reservation {
 
 
     // 리뷰 작성 여부(리뷰 작성 가능한 예약 조건에 필요함)
-    //리뷰작성 완료시 해당 예약의 reviewed필드를 true로 저장해줘야됨
+    //리뷰작성 완료시 해당 예약의 reviewed필드를 true로 저장해줘야됨 -> COMPLETED로 대체
     private boolean reviewed;
-    public void markReviewed() {
-        this.reviewed = true;
-    }
+
 
     public void cancel() {
         this.status = ReservationStatus.CANCELLED;

--- a/src/main/java/com/example/sodamsodam/apps/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/repository/ReservationRepository.java
@@ -1,0 +1,18 @@
+package com.example.sodamsodam.apps.reservation.repository;
+
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    //1. 유저 전체 예약 조회(빠른 날짜부터)
+    List<Reservation> findByUser_UserIdOrderByReservedAtAsc(Long userId);
+
+    // 2. 유저의 상태별 예약 조회 (빠른 날짜부터)
+    List<Reservation> findByUser_UserIdAndStatusOrderByReservedAtAsc(Long userId, Reservation.ReservationStatus status);
+
+    // 3. 유저의 리뷰 안한 예약만 조회 (리뷰 작성 가능 목록용)
+    List<Reservation> findByUser_UserIdAndReviewedFalse(Long userId);
+}

--- a/src/main/java/com/example/sodamsodam/apps/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/sodamsodam/apps/reservation/service/ReservationService.java
@@ -1,4 +1,75 @@
 package com.example.sodamsodam.apps.reservation.service;
 
+
+import com.example.sodamsodam.apps.reservation.dto.ReservationCreateRequest;
+import com.example.sodamsodam.apps.reservation.entity.Reservation;
+import com.example.sodamsodam.apps.reservation.repository.ReservationRepository;
+import com.example.sodamsodam.apps.user.entity.UserPersonalInfo;
+import com.example.sodamsodam.apps.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
 public class ReservationService {
+
+    private final ReservationRepository reservationRepository; //DB접근
+    private final UserRepository userRepository;
+
+    public Long createReservation(ReservationCreateRequest request) {
+        UserPersonalInfo user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다"));
+
+        Reservation reservation = Reservation.builder()
+                .user(user)
+                .placeName(request.getPlaceName())
+                .kakaoPlaceId(request.getKakaoPlaceId())
+                .address(request.getAddress())
+                .reservedAt(request.getReservedAt())
+                .status(Reservation.ReservationStatus.UPCOMING)
+                .reviewed(false)
+                .build();
+
+        Reservation saved = reservationRepository.save(reservation);
+        return saved.getReservationId();
+    }
+
+
+
+    public List<Reservation> getReservations(Long userId) {
+        return reservationRepository.findByUser_UserIdOrderByReservedAtAsc(userId);
+    }// 예약 일자 오름차순(빠른 날자부터)가져옴
+
+    public List<Reservation> getReservationsByStatus(Long userId, Reservation.ReservationStatus status) {
+        return reservationRepository.findByUser_UserIdAndStatusOrderByReservedAtAsc(userId, status);
+    }//상태에 따라 분류 가능
+
+    public Reservation getReservationDetail(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
+    }
+
+    public Reservation cancelReservation(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
+
+        reservation.cancel(); // 상태 변경
+        return reservationRepository.save(reservation); // 변경사항 저장
+    }
+
+
+    public List<Reservation> getNotReviewedReservations(Long userId) {
+        List<Reservation> reservations = reservationRepository.findByUser_UserIdAndReviewedFalse(userId);
+
+        // 리뷰 가능 조건 추가
+        return reservations.stream()
+                .filter(r -> r.getStatus() == Reservation.ReservationStatus.COMPLETED)
+                .filter(r -> r.getReservedAt().toLocalDate().plusDays(3).isAfter(LocalDate.now()))
+                .toList();
+    }
+
 }


### PR DESCRIPTION
##  작업 내용

- `/api/v1/reservations/user/{userId}/filter` GET API 추가
  - 유저 ID 기반 예약 목록 조회
  - `status` 쿼리 파라미터를 통해 UPCOMING, COMPLETED, CANCELLED 상태별 필터링 가능
  - 모든 예약 조회 또는 특정 상태 필터링 조회 모두 지원
- 리뷰 작성 가능 예약 목록 조회 로직 개선
  - 조건: `COMPLETED` 상태, `reviewed = false`, `예약일 +3일 > 오늘`
  - 조건을 만족하는 예약만 반환되도록 필터링 적용

##  참고 사항

- 리뷰 가능한 예약이 없는 경우 , 예약이 없는 경우 UX를 고려해 프론트에서 안내 메시지 처리 필요
- `//리뷰작성 완료 시 reviewed 필드를 true로 저장해줘야됨 -> COMPLETED로 대체` 주석은 틀린 내용입니다 
  - 리뷰 작성 완료 시 반드시 `reviewed = true`로 설정해야 리뷰 중복 작성 방지됩니다 
